### PR TITLE
Declares !default variable;

### DIFF
--- a/_breakpoints.scss
+++ b/_breakpoints.scss
@@ -1,3 +1,11 @@
+$grid-breakpoints: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px
+) !default;
+
 // Breakpoint viewport sizes and media queries.
 //
 // Breakpoints are defined as a map of (name: minimum width), order from small to large:


### PR DESCRIPTION
Supports Sass's newer `@use` syntax, allowing users to import these mixins as a namespaced Sass module:

```scss
@use './modules/viewport' as vp;

@use 'sass-breakpoints-mixins/breakpoints' as bp with (
	$grid-breakpoints: (
		small: map-get(vp.$min-width, 'small'),
		medium: map-get(vp.$min-width, 'medium'),
		large: map-get(vp.$min-width, 'large'),
		xlarge: map-get(vp.$min-width, 'xlarge'),
	)
);
```

Without a `!default` variable definition provided by this package, a user cannot configure their own `$grid-breakpoints` variable when initially invoking `@use` with this package. The `dart-sass` (`sass`) compiler will throw the following exception:

```bash
Error: This variable was not declared with !default in the @used module.
  ╷
4 │ ┌     $grid-breakpoints: (
5 │ │         small: map-get(vp.$min-width, 'small'),
6 │ │         medium: map-get(vp.$min-width, 'medium'),
7 │ │         large: map-get(vp.$min-width, 'large'),
8 │ │         xlarge: map-get(vp.$min-width, 'xlarge'),
9 │ └     )
  ╵
```
